### PR TITLE
Add ArrayExtension test files and modify project settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -446,6 +446,9 @@ Temporary Items
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
+.idea/
+.idea/.idea.HeroKit/*
+.idea/.idea.HeroKit/**
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml

--- a/HeroKit.Tests/Arrays/ArrayControlExtensionsTests.cs
+++ b/HeroKit.Tests/Arrays/ArrayControlExtensionsTests.cs
@@ -1,0 +1,34 @@
+using HeroKit.Arrays;
+
+namespace HeroKit.Tests.Arrays;
+
+using Xunit;
+
+public class ArrayControlExtensionsTests
+{
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData(new int[] { }, true)]
+    [InlineData(new[] { 1 }, false)]
+    [InlineData(new[] { 1, 2, 3 }, false)]
+    [InlineData(new object[] { null, null }, false)]
+    [InlineData(new object[] { null, "Test" }, false)]
+    [InlineData(new string[] { "Test", "Test2" }, false)]
+    public void IsNullOrEmptyTests<T>(T[] array, bool expected)
+    {
+        Assert.Equal(expected, array.IsNullOrEmpty());
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData(new int[] { }, false)]
+    [InlineData(new[] { 1 }, true)]
+    [InlineData(new[] { 1, 2, 3 }, true)]
+    [InlineData(new object[] { null, null }, true)]
+    [InlineData(new object[] { null, "Test" }, true)]
+    [InlineData(new string[] { "Test", "Test2" }, true)]
+    public void IsNotNullOrEmptyTestsForInt<T>(T[] array, bool expected)
+    {
+        Assert.Equal(expected, array.IsNotNullOrEmpty());
+    }
+}

--- a/HeroKit.Tests/Arrays/ArrayConversionExtensionsTests.cs
+++ b/HeroKit.Tests/Arrays/ArrayConversionExtensionsTests.cs
@@ -1,0 +1,76 @@
+namespace HeroKit.Tests.Arrays;
+
+using System;
+using System.Collections.Generic;
+using System.Web;
+using HeroKit.Arrays;
+
+public class ArrayConversionExtensionsTests
+{
+    private static int MapFunction(object value) => (int)value * 10;
+
+    [Fact]
+    public void ToListShouldTurnArrayToListByApplyingMapFunction()
+    {
+        // Arrange
+        int[] array = { 1, 2, 3, 4, 5 };
+
+        // Act
+        List<int> result = array.ToList(MapFunction);
+
+        // Assert
+        Assert.Equal(new List<int> { 10, 20, 30, 40, 50 }, result);
+    }
+
+    [Fact]
+    public void ToListShouldReturnEmptyListWhenInputArrayIsNullOrEmpty()
+    {
+        // Arrange
+        int[] array = Array.Empty<int>();
+
+        // Act
+        List<int> result = array.ToList(MapFunction);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ToListShouldReturnEmptyListWhenMapFunctionIsNull()
+    {
+        // Arrange
+        int[] array = { 1, 2, 3, 4, 5 };
+
+        // Act
+        List<int> result = array.ToList(mapFunction: null);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void UrlTokenEncodeShouldEncodeArrayToString()
+    {
+        // Arrange
+        byte[] byteArray = { 1, 2, 3, 4, 5 };
+
+        // Act
+        string result = byteArray.UrlTokenEncode();
+
+        // Assert
+        Assert.Equal(HttpUtility.UrlEncode(byteArray), result);
+    }
+
+    [Fact]
+    public void UrlTokenEncodeShouldReturnEmptyStringWhenNullOrEmptyInput()
+    {
+        // Arrange
+        byte[] array = Array.Empty<byte>();
+
+        // Act
+        string result = array.UrlTokenEncode();
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+}

--- a/HeroKit.Tests/Arrays/ArrayManipulationExtensionsTests.cs
+++ b/HeroKit.Tests/Arrays/ArrayManipulationExtensionsTests.cs
@@ -1,0 +1,48 @@
+namespace HeroKit.Tests.Arrays;
+
+using HeroKit.Arrays;
+
+public class ArrayManipulationExtensionsTests
+{
+    [Fact]
+    public void InsertItemsShouldReplaceArrayItems()
+    {
+        // Arrange
+        int[] array = { 0, 0, 0, 0, 0 };
+        int[] items = { 1, 2, 3, 4, 5 };
+
+        // Act
+        array.InsertItems(items);
+
+        // Assert
+        Assert.Equal(items, array);
+    }
+
+    [Fact]
+    public void InsertItemsWithMoreItemsThanArraySizeShouldNotThrowException()
+    {
+        // Arrange
+        int[] array = { 0, 0, 0, 0, 0 };
+        int[] items = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+        // Act
+        array.InsertItems(items);
+
+        // Assert
+        Assert.Equal(items.Take(array.Length), array);
+    }
+
+    [Fact]
+    public void InsertItemsWithLessItemsThanArraySizeShouldOnlyReplaceSomeItems()
+    {
+        // Arrange
+        int[] array = { 0, 0, 0, 0, 0 };
+        int[] items = { 1, 2, 3 };
+
+        // Act
+        array.InsertItems(items);
+
+        // Assert
+        Assert.Equal(new[] { 1, 2, 3, 0, 0 }, array);
+    }
+}

--- a/HeroKit.Tests/HeroKit.Tests.csproj
+++ b/HeroKit.Tests/HeroKit.Tests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <Nullable>disable</Nullable>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/HeroKit/Arrays/ArrayConversionExtensions.cs
+++ b/HeroKit/Arrays/ArrayConversionExtensions.cs
@@ -17,7 +17,7 @@ public static class ArrayConversionExtensions
     public static List<T> ToList<T>(this T[] items, Func<object, T> mapFunction)
     {
         if (items.IsNullOrEmpty() || mapFunction.IsNull())
-            return new List<T>();
+            return [];
 
         return items.Cast<object>().Select((_, i) => mapFunction(items.GetValue(i)))
                     .Where(val => val.IsNotNull())


### PR DESCRIPTION
Three new test files were added related to ArrayExtensions: ArrayConversionExtensionsTests, ArrayControlExtensionsTests, and ArrayManipulationExtensionsTests. These contain unit tests for the ArrayExtensions methods. The project file, HeroKit.Tests.csproj, was also modified to disable the Nullable setting. In ArrayConversionExtensions.cs, the code was updated to return an empty array instead of a new list when conditions are unmet.