### PR TITLE
Add extension methods for various types

### DIFF
--- a/HeroKit/Comparers/NameEqualityComparer.cs
+++ b/HeroKit/Comparers/NameEqualityComparer.cs
@@ -1,0 +1,39 @@
+namespace HeroKit.Comparers;
+
+/// <summary>
+/// Represents an equality comparer for comparing string values based on name comparison using a case-insensitive comparison.
+/// </summary>
+public class NameEqualityComparer : IEqualityComparer<string>
+{
+    /// <summary>
+    /// Gets the default instance of <see cref="IEqualityComparer{string}"/> that uses the <see cref="NameEqualityComparer"/> implementation.
+    /// </summary>
+    /// <returns>The default instance of <see cref="IEqualityComparer{string}"/>.</returns>
+    public static IEqualityComparer<string> Default => new NameEqualityComparer();
+
+    /// <summary>
+    /// Determines whether two specified strings have the same value, ignoring the case.
+    /// </summary>
+    /// <param name="source">The first string to compare.</param>
+    /// <param name="control">The second string to compare.</param>
+    /// <returns>
+    /// true if the two strings are equal; otherwise, false.
+    /// </returns>
+    public bool Equals(string source, string control)
+    {
+        if (source == null && control == null)
+            return true;
+
+        if (source == null || control == null)
+            return false;
+
+        return source.Equals(control, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the hash code for the specified string object.
+    /// </summary>
+    /// <param name="@object">The string object for which to get the hash code.</param>
+    /// <returns>The hash code value for the <paramref name="@object"/> parameter.</returns>
+    public int GetHashCode(string @object) => @object.GetHashCode();
+}

--- a/HeroKit/Enums/EnumExtensions.cs
+++ b/HeroKit/Enums/EnumExtensions.cs
@@ -1,0 +1,54 @@
+namespace HeroKit.Enums;
+
+/// <summary>
+/// Provides extension methods for working with enums.
+/// </summary>
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Checks if the specified value is defined in the given enumeration type.
+    /// </summary>
+    /// <typeparam name="T">The enum type to be checked.</typeparam>
+    /// <param name="value">The value to be checked.</param>
+    /// <returns>True if the value is defined in the enum type; otherwise, false.</returns>
+    public static bool IsDefined<T>(this T value) where T : struct, IConvertible => Enum.IsDefined(typeof(T), value);
+
+    /// <summary>
+    /// Converts an enum value to its equivalent byte representation.
+    /// </summary>
+    /// <param name="value">The enum value to be converted.</param>
+    /// <returns>The byte representation of the enum value.</returns>
+    /// <remarks>
+    /// This method is an extension method that can be called on any enum value.
+    /// </remarks>
+    public static byte ToByte(this Enum value) => Convert.ToByte(value);
+
+    /// <summary>
+    /// Gets the string representation of the specified enum value.
+    /// </summary>
+    /// <typeparam name="T">The enum type.</typeparam>
+    /// <param name="value">The enum value.</param>
+    /// <returns>The string representation of the enum value.</returns>
+    public static string GetValue<T>(this Enum value) => Convert.ChangeType(value, typeof(T)).ToString();
+
+    /// <summary>
+    /// Returns a list of all values defined in the given enumeration type.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <returns>A list of all values defined in the enum type.</returns>
+    public static List<TEnum> ToList<TEnum>()
+    {
+        var type = typeof(TEnum);
+
+        if (type.BaseType == typeof(Enum))
+            throw new ArgumentException("T must be type of System.Enum");
+
+        var values = Enum.GetValues(type);
+
+        return values.Length switch
+        {
+            > 0 => values.Cast<TEnum>().ToList(),
+            _ => []
+        };
+    }
+}

--- a/HeroKit/Guids/GuidExtensions.cs
+++ b/HeroKit/Guids/GuidExtensions.cs
@@ -1,0 +1,35 @@
+namespace HeroKit.Guids;
+
+/// <summary>
+/// Contains extension methods for <see cref="Guid"/> type.
+/// </summary>
+public static class GuidExtensions
+{
+    /// <summary>
+    /// Determines whether a <see cref="Guid"/> is empty.
+    /// </summary>
+    /// <param name="target">The <see cref="Guid"/> to check.</param>
+    /// <returns>true if the <see cref="Guid"/> is empty; otherwise, false.</returns>
+    public static bool IsEmpty(this Guid target) => target == Guid.Empty;
+
+    /// <summary>
+    /// Determines whether a <see cref="Guid"/> is not empty.
+    /// </summary>
+    /// <param name="target">The <see cref="Guid"/> to check.</param>
+    /// <returns>true if the <see cref="Guid"/> is not empty; otherwise, false.</returns>
+    public static bool IsNotEmpty(this Guid target) => !target.IsEmpty();
+
+    /// <summary>
+    /// Determines whether a <see cref="Guid"/> is null or empty.
+    /// </summary>
+    /// <param name="target">The <see cref="Guid"/> to check.</param>
+    /// <returns>true if the <see cref="Guid"/> is null or empty; otherwise, false.</returns>
+    public static bool IsNullOrEmpty(this Guid? target) => !target.HasValue || target.Value.IsEmpty();
+
+    /// <summary>
+    /// Determines whether a <see cref="Guid"/> is not null or empty.
+    /// </summary>
+    /// <param name="target">The <see cref="Guid"/> to check.</param>
+    /// <returns>true if the <see cref="Guid"/> is not null or empty; otherwise, false.</returns>
+    public static bool IsNotNullOrEmpty(this Guid? target) => !target.IsNullOrEmpty();
+}

--- a/HeroKit/Integers/IntegerExtensions.cs
+++ b/HeroKit/Integers/IntegerExtensions.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using HeroKit.Objects;
+
+namespace HeroKit.Integers;
+
+/// <summary>
+/// Provides extension methods for integers.
+/// </summary>
+public static class IntegerExtensions
+{
+    /// <summary>
+    /// Returns half of the given integer.
+    /// </summary>
+    /// <param name="source">The integer to halve.</param>
+    /// <returns>The result of dividing the given integer by 2.</returns>
+    public static int Half(this int source) => source / 2;
+
+    /// <summary>
+    /// Returns the cube of the given integer.
+    /// </summary>
+    /// <param name="source">The integer to cube.</param>
+    /// <returns>The result of raising the given integer to the power of 3.</returns>
+    public static int Cube(this int source) => (int)Math.Pow(source, 3);
+
+    /// <summary>
+    /// Returns the square of the given integer.
+    /// </summary>
+    /// <param name="source">The integer to square.</param>
+    /// <returns>The result of multiplying the given integer by itself.</returns>
+    public static int Square(this int source) => (int)Math.Pow(source, 2);
+
+    /// <summary>
+    /// Determines whether the given number is an even number.
+    /// </summary>
+    /// <param name="number">The number to check.</param>
+    /// <returns>true if the number is even, false otherwise.</returns>
+    public static bool IsEvenNumber(this int number) => ((number % 2) == 0);
+
+    /// <summary>
+    /// Determines whether the given number is an odd number.
+    /// </summary>
+    /// <param name="number">The number to check.</param>
+    /// <returns>true if the number is odd, false otherwise.</returns>
+    public static bool IsOddNumber(this int number) => ((number % 2) == 1);
+
+    /// <summary>
+    /// Returns the month name of the given integer value.
+    /// </summary>
+    /// <param name="value">The integer value representing a month (1-12).</param>
+    /// <param name="cultureInfo">The culture information to use for month names (optional).</param>
+    /// <returns>The month name corresponding to the given value, or an empty string if the value is out of range.</returns>
+    public static string ToMonthString(this int value, CultureInfo cultureInfo = null)
+    {
+        if (cultureInfo.IsNull())
+        {
+            cultureInfo = CultureInfo.CurrentCulture;
+        }
+        
+        return value switch
+        {
+            >= 1 and <= 12 => cultureInfo.DateTimeFormat.GetMonthName(value),
+            _ => ""
+        };
+    }
+
+    /// <summary>
+    /// Converts the given integer point value to pixel value.
+    /// </summary>
+    /// <param name="point">The integer point value.</param>
+    /// <returns>The pixel value after conversion.</returns>
+    public static decimal ToPixel(this int point) => decimal.Truncate(point * 4 / 5) + 1;
+
+    /// <summary>
+    /// Returns the given number of seconds as milliseconds.
+    /// </summary>
+    /// <param name="source">The number of seconds.</param>
+    /// <returns>The number of seconds converted to milliseconds.</returns>
+    public static int Seconds(this int source) => source * 1000;
+}

--- a/HeroKit/Objects/ObjectConversionExtensions.cs
+++ b/HeroKit/Objects/ObjectConversionExtensions.cs
@@ -36,4 +36,25 @@ public static class ObjectConversionExtensions
 
         return (T)Convert.ChangeType(source, type, CultureInfo.InvariantCulture);
     }
+
+    /// <summary>
+    /// Tries to cast an object to the specified type.
+    /// </summary>
+    /// <typeparam name="T">The target type to cast to.</typeparam>
+    /// <param name="source">The object to be casted.</param>
+    /// <param name="result">The result of the cast operation if successful, or the default value of type T if unsuccessful.</param>
+    /// <returns>True if the cast operation is successful, false otherwise.</returns>
+    public static bool TryCast<T>(this object source, out T result)
+    {
+        try
+        {
+            result = source.ConvertTo<T>();
+            return true;
+        }
+        catch
+        {
+            result = default(T);
+            return false;
+        }
+    }
 }

--- a/HeroKit/Properties/PropertyInfoExtensions.cs
+++ b/HeroKit/Properties/PropertyInfoExtensions.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using HeroKit.Objects;
+using HeroKit.Types;
+
+namespace HeroKit.Properties;
+
+/// <summary>
+/// Provides extension methods for PropertyInfo values.
+/// </summary>
+public static class PropertyInfoExtensions
+{
+    /// <summary>
+    /// Determines if a value can be assigned to a PropertyInfo.
+    /// </summary>
+    /// <param name="property">The PropertyInfo to check.</param>
+    /// <param name="value">The value to be assigned.</param>
+    /// <returns>True if the value can be assigned, false otherwise.</returns>
+    public static bool CanAssignValue(this PropertyInfo property, object value)
+    {
+        return value.IsNull() ? property.IsNullable() : property.PropertyType.IsInstanceOfType(value);
+    }
+
+    /// <summary>
+    /// Determines if the PropertyInfo is nullable.
+    /// </summary>
+    /// <param name="property">The PropertyInfo to check.</param>
+    /// <returns>True if the PropertyInfo is nullable, false otherwise.</returns>
+    public static bool IsNullable(this PropertyInfo property) => property.PropertyType.IsNullable();
+
+    /// <summary>
+    /// Sets the value of a PropertyInfo on an instance of a class.
+    /// </summary>
+    /// <typeparam name="T">The type of the instance.</typeparam>
+    /// <param name="property">The PropertyInfo to set.</param>
+    /// <param name="instance">The instance of the class.</param>
+    /// <param name="value">The value to be set.</param>
+    public static void SetValue<T>(this PropertyInfo property, T instance, object value)
+    {
+        var constructedMethod = typeof(ObjectConversionExtensions).GetMethod("TryCast")!
+            .MakeGenericMethod(property.PropertyType);
+
+        object valueSet = null;
+        var parameters = new[] { value, null };
+
+        if (Convert.ToBoolean(constructedMethod.Invoke(null, parameters)))
+            valueSet = parameters[1];
+
+        if (!property.CanAssignValue(valueSet))
+            return;
+        property.SetValue(instance, valueSet, null);
+    }
+}


### PR DESCRIPTION
This commit introduces multiple extension methods for various types that work to assist in object conversion, integer manipulation, checking the characteristics/status of a Guid, enum conversion methods, and a name equality comparer. Useful methods include ones to determine if a value can be assigned to a PropertyInfo, if a Guid is empty, and various mathematical manipulations on integers.