### PR TITLE
Update project version and copyright year

### DIFF
--- a/HeroKit/HeroKit.csproj
+++ b/HeroKit/HeroKit.csproj
@@ -13,12 +13,12 @@
         <RepositoryUrl>git@github.com:emreakdemir/herokit.git</RepositoryUrl>
         <PackageTags>csharp, dotnet7, extensions</PackageTags>
         <AssemblyVersion>1.0.0</AssemblyVersion>
-        <Version>1.0.0-alpha.4</Version>
+        <Version>1.0.0-alpha.6</Version>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Description>The HeroKit library, providing utility operations, offers a comprehensive set of extension methods for controlling, converting, and manipulating various data types. Designed for projects developed in C#, this extensive library enables performing diverse operations on different data types, ranging from arrays to date-time values, objects, and strings etc.</Description>
-        <Copyright>Copyright © 2023 Emre Akdemir</Copyright>
+        <Copyright>Copyright © 2024 Emre Akdemir</Copyright>
         <RepositoryType>git</RepositoryType>
         <EmbedAllSources>true</EmbedAllSources>
         <PackageReleaseNotes>added new extensions and tests</PackageReleaseNotes>


### PR DESCRIPTION
The HeroKit project's version has been updated from 1.0.0-alpha.4 to 1.0.0-alpha.6. Additionally, the copyright year has also been updated from 2023 to 2024.